### PR TITLE
Dockerfile added

### DIFF
--- a/BAA/dockerfile
+++ b/BAA/dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.20-alpine
+WORKDIR /app
+##  NOTE: you can add in a go.sum to this as well
+##      but this is still used to have everything
+##      ready for building.
+COPY go.mod ./
+RUN go mod download
+COPY . .
+## NOTE: here we must use RUN here. But the other stages 
+## Will not run if this is CMD.
+RUN go test ./...
+
+##  Stage 2: Build the application (only if tests pass)
+FROM golang:1.20-alpine AS final
+WORKDIR /app
+COPY --from=builder /app /app
+RUN go build -o myapp .
+
+## Define the command to run the application
+CMD ["./myapp"]


### PR DESCRIPTION
I added a dockerfile to BAA quickly let me know if it is ok,
during testing the docker container the test failed, and outputed 
```sh
 docker build .
[+] Building 19.4s (10/12)
 => [internal] load build definition from Dockerfile                                                                                          0.0s
 => => transferring dockerfile: 38B                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                             0.0s
 => => transferring context: 2B                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/golang:1.20-alpine                                                                         5.9s
 => [builder 1/6] FROM docker.io/library/golang:1.20-alpine@sha256:e47f121850f4e276b2b210c56df3fda9191278dd84a3a442bfe0b09934462a8f           0.0s
 => [internal] load build context                                                                                                             0.0s
 => => transferring context: 192B                                                                                                             0.0s
 => CACHED [builder 2/6] WORKDIR /app                                                                                                         0.0s
 => [builder 3/6] COPY go.mod ./                                                                                                              0.0s
 => [builder 4/6] RUN go mod download                                                                                                         0.4s
 => [builder 5/6] COPY . .                                                                                                                    0.0s
 => ERROR [builder 6/6] RUN go test ./...                                                                                                    12.9s
------
 > [builder 6/6] RUN go test ./...:
#10 12.62 example.com/server: cannot compile Go 1.22 code
#10 12.75 FAIL  example.com/server [build failed]
#10 12.75 FAIL
------
executor failed running [/bin/sh -c go test ./...]: exit code: 1
```

Which is to be expected, but a good starting point the tests did stop the build from going through.